### PR TITLE
use stat from dir info on propfind

### DIFF
--- a/webdav/file.go
+++ b/webdav/file.go
@@ -163,6 +163,7 @@ type memFS struct {
 //   - "/", "foo", false
 //   - "/foo/", "bar", false
 //   - "/foo/bar/", "x", true
+//
 // The frag argument will be empty only if dir is the root node and the walk
 // ends at that root node.
 func (fs *memFS) walk(op, fullname string, f func(dir *memFSNode, frag string, final bool) error) error {
@@ -782,11 +783,11 @@ func walkFS(ctx context.Context, fs FileSystem, depth int, name string, info os.
 		return walkFn(name, info, err)
 	}
 
-	for _, fileInfo := range fileInfos {
-		filename := path.Join(name, fileInfo.Name())
+	for _, dirFileInfo := range fileInfos {
+		filename := path.Join(name, dirFileInfo.Name())
 		fileInfo, err := fs.Stat(ctx, filename)
 		if err != nil {
-			if err := walkFn(filename, fileInfo, err); err != nil && err != filepath.SkipDir {
+			if err := walkFn(filename, dirFileInfo, err); err != nil && err != filepath.SkipDir {
 				return err
 			}
 		} else {

--- a/webdav/prop.go
+++ b/webdav/prop.go
@@ -175,6 +175,7 @@ func props(ctx context.Context, fs FileSystem, ls LockSystem, name string, pname
 
 	return propsForFile(ctx, f, fs, ls, name, pnames)
 }
+
 func propsForFile(ctx context.Context, f File, fs FileSystem, ls LockSystem, name string, pnames []xml.Name) ([]Propstat, error) {
 	fi, err := f.Stat()
 	if err != nil {
@@ -282,6 +283,7 @@ func allprop(ctx context.Context, fs FileSystem, ls LockSystem, name string, inc
 	return allpropForFile(ctx, f, fs, ls, name, include)
 
 }
+
 func allpropForFile(ctx context.Context, f File, fs FileSystem, ls LockSystem, name string, include []xml.Name) ([]Propstat, error) {
 	pnames, err := propnamesForFile(f)
 	if err != nil {

--- a/webdav/prop.go
+++ b/webdav/prop.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"mime"
 	"net/http"
 	"os"
@@ -54,13 +55,12 @@ type Propstat struct {
 // makePropstats returns a slice containing those of x and y whose Props slice
 // is non-empty. If both are empty, it returns a slice containing an otherwise
 // zero Propstat whose HTTP status code is 200 OK.
-func makePropstats(x, y Propstat) []Propstat {
-	pstats := make([]Propstat, 0, 2)
-	if len(x.Props) != 0 {
-		pstats = append(pstats, x)
-	}
-	if len(y.Props) != 0 {
-		pstats = append(pstats, y)
+func makePropstats(stats ...Propstat) []Propstat {
+	pstats := make([]Propstat, 0, len(stats))
+	for _, stat := range stats {
+		if len(stat.Props) != 0 {
+			pstats = append(pstats, stat)
+		}
 	}
 	if len(pstats) == 0 {
 		pstats = append(pstats, Propstat{
@@ -172,8 +172,13 @@ func props(ctx context.Context, fs FileSystem, ls LockSystem, name string, pname
 		return nil, err
 	}
 	defer f.Close()
+
+	return propsForFile(ctx, f, fs, ls, name, pnames)
+}
+func propsForFile(ctx context.Context, f File, fs FileSystem, ls LockSystem, name string, pnames []xml.Name) ([]Propstat, error) {
 	fi, err := f.Stat()
 	if err != nil {
+		fmt.Printf("FileProp error %v\n", err)
 		return nil, err
 	}
 	isDir := fi.IsDir()
@@ -188,6 +193,8 @@ func props(ctx context.Context, fs FileSystem, ls LockSystem, name string, pname
 
 	pstatOK := Propstat{Status: http.StatusOK}
 	pstatNotFound := Propstat{Status: http.StatusNotFound}
+	pstatForbidden := Propstat{Status: http.StatusForbidden}
+	pstatInternal := Propstat{Status: http.StatusInternalServerError}
 	for _, pn := range pnames {
 		// If this file has dead properties, check if they contain pn.
 		if dp, ok := deadProps[pn]; ok {
@@ -197,20 +204,27 @@ func props(ctx context.Context, fs FileSystem, ls LockSystem, name string, pname
 		// Otherwise, it must either be a live property or we don't know it.
 		if prop := liveProps[pn]; prop.findFn != nil && (prop.dir || !isDir) {
 			innerXML, err := prop.findFn(ctx, fs, ls, name, fi)
-			if err != nil {
-				return nil, err
+			if err == nil {
+				pstatOK.Props = append(pstatOK.Props, Property{
+					XMLName:  pn,
+					InnerXML: []byte(innerXML),
+				})
+			} else if errors.Is(err, os.ErrPermission) {
+				pstatForbidden.Props = append(pstatForbidden.Props, Property{
+					XMLName: pn,
+				})
+			} else {
+				pstatInternal.Props = append(pstatInternal.Props, Property{
+					XMLName: pn,
+				})
 			}
-			pstatOK.Props = append(pstatOK.Props, Property{
-				XMLName:  pn,
-				InnerXML: []byte(innerXML),
-			})
 		} else {
 			pstatNotFound.Props = append(pstatNotFound.Props, Property{
 				XMLName: pn,
 			})
 		}
 	}
-	return makePropstats(pstatOK, pstatNotFound), nil
+	return makePropstats(pstatOK, pstatNotFound, pstatForbidden, pstatInternal), nil
 }
 
 // Propnames returns the property names defined for resource name.
@@ -220,10 +234,15 @@ func propnames(ctx context.Context, fs FileSystem, ls LockSystem, name string) (
 		return nil, err
 	}
 	defer f.Close()
+	return propnamesForFile(f)
+}
+
+func propnamesForFile(f File) ([]xml.Name, error) {
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, err
 	}
+
 	isDir := fi.IsDir()
 
 	var deadProps map[xml.Name]Property
@@ -255,7 +274,16 @@ func propnames(ctx context.Context, fs FileSystem, ls LockSystem, name string) (
 //
 // See http://www.webdav.org/specs/rfc4918.html#METHOD_PROPFIND
 func allprop(ctx context.Context, fs FileSystem, ls LockSystem, name string, include []xml.Name) ([]Propstat, error) {
-	pnames, err := propnames(ctx, fs, ls, name)
+	f, err := fs.OpenFile(ctx, name, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return allpropForFile(ctx, f, fs, ls, name, include)
+
+}
+func allpropForFile(ctx context.Context, f File, fs FileSystem, ls LockSystem, name string, include []xml.Name) ([]Propstat, error) {
+	pnames, err := propnamesForFile(f)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +297,7 @@ func allprop(ctx context.Context, fs FileSystem, ls LockSystem, name string, inc
 			pnames = append(pnames, pn)
 		}
 	}
-	return props(ctx, fs, ls, name, pnames)
+	return propsForFile(ctx, f, fs, ls, name, pnames)
 }
 
 // Patch patches the properties of resource name. The return values are
@@ -477,4 +505,31 @@ func findSupportedLock(ctx context.Context, fs FileSystem, ls LockSystem, name s
 		`<D:lockscope><D:exclusive/></D:lockscope>` +
 		`<D:locktype><D:write/></D:locktype>` +
 		`</D:lockentry>`, nil
+}
+
+type propstatFallback struct {
+	info fs.FileInfo
+}
+
+func (p *propstatFallback) Close() error {
+	return nil
+}
+
+func (p *propstatFallback) Stat() (fs.FileInfo, error) {
+	return p.info, nil
+}
+
+func (p *propstatFallback) Write([]byte) (int, error) {
+	return 0, errors.New("unimplemeneted")
+}
+
+func (p *propstatFallback) Read([]byte) (int, error) {
+	return 0, errors.New("unimplemeneted")
+}
+
+func (p *propstatFallback) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("unimplemeneted")
+}
+func (p *propstatFallback) Readdir(count int) ([]fs.FileInfo, error) {
+	return nil, errors.New("unimplemented")
 }


### PR DESCRIPTION
When we do a walk on a propfind, we first read the directory entries for the currently directory prior to recursing into them. If, on recurse, we failed to read the properties for a subdirectory (for example, because of permissions), we would just skip that directory entirely.  This lead to unexpected behaviour, particularly since most file systems show things in a given directory, regardless of whether they themselves may be read.

Fix that problem by using the direcetory info we received from the parent directory when doing the recursion as a fallback in the error case.