### PR TITLE
fix: add lockdiscovery propegation

### DIFF
--- a/webdav/lock.go
+++ b/webdav/lock.go
@@ -69,10 +69,6 @@ type LockSystem interface {
 	// contain whitespace.
 	Create(now time.Time, details LockDetails) (token string, err error)
 
-	// Lockdetails is used to discover lockdetails on a file if it exists
-	// if not implemented, return nil lockDetails
-	LockDetails(path string, fi os.FileInfo) (ld *LockDetails, err error)
-
 	// Refresh refreshes the lock with the given token.
 	//
 	// If Refresh returns ErrLocked then the Handler will write a "423 Locked"
@@ -109,6 +105,12 @@ type LockDeleter interface {
 	// If Delete returns any non-nil error  the Handler will write a "409
 	// Conflict" HTTP status
 	Delete(now time.Time, name string) error
+}
+
+// LockInspector extends a LockSystem to support inspecting locks on a file for lockdiscovery
+type LockInspector interface {
+	// Lockdetails is used to discover lockdetails on a file if it exists
+	LockDetails(path string, fi os.FileInfo) (ld *LockDetails, err error)
 }
 
 // LockDetails are a lock's metadata.

--- a/webdav/lock.go
+++ b/webdav/lock.go
@@ -7,6 +7,7 @@ package webdav
 import (
 	"container/heap"
 	"errors"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -67,6 +68,10 @@ type LockSystem interface {
 	// URI as defined by RFC 3986, Section 4.3. In particular, it should not
 	// contain whitespace.
 	Create(now time.Time, details LockDetails) (token string, err error)
+
+	// Lockdetails is used to discover lockdetails on a file if it exists
+	// if not implemented, return nil lockDetails
+	LockDetails(path string, fi os.FileInfo) (ld *LockDetails, err error)
 
 	// Refresh refreshes the lock with the given token.
 	//
@@ -162,6 +167,10 @@ func (m *memLS) collectExpiredNodes(now time.Time) {
 		}
 		m.remove(m.byExpiry[0])
 	}
+}
+
+func (m *memLS) LockDetails(path string, fi os.FileInfo) (ld *LockDetails, err error) {
+	return nil, nil
 }
 
 func (m *memLS) Confirm(now time.Time, name0, name1 string, conditions ...Condition) (func(), error) {


### PR DESCRIPTION
This adds support for a webdav locker to propegate lockdiscovery information.

A LockDetails call has been added to the webdav Locker interface. An implementing locker will receive a path and the Fileinfo from the file and return a pointer to a filled out LockDetails. A non-implementing locker can return null.